### PR TITLE
Remove dependency on the standard library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morse"
-version = "0.1.0"
-authors = ["Pieter Vantorre <pietervantorre@gmail.com>"]
+version = "0.1.1"
+authors = ["Pieter Vantorre <pietervantorre@gmail.com>", "Evan Pratten <ewpratten@gmail.com>"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Morse code translator crate
+[![Crates.io](https://img.shields.io/crates/v/morse)](https://crates.io/crates/morse) [![Documentation](https://docs.rs/morse/badge.svg)](https://docs.rs/morse)
+
+Provides functionality for encoding and decoding text to and from a morse code representation.
+
+## Installation
+
+### From Crates.io
+
+```sh
+cargo install morse
+```
+
+### From Source
+
+```sh
+git clone https://github.com/NuclearCookie/morse
+cd morse
+cargo install --path .
+```

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,0 @@
-#Morse code translator crate
-
-Provides functionality for encoding and decoding text to and from a morse code representation.

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,8 @@
 //! Morse to Ascii
 use TranslationError;
 
+use alloc::string::{String,ToString};
+
 /// Decodes a morse representation string into an ascii string
 ///
 /// # Examples

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,6 +1,8 @@
 //! Ascii to Morse
 use TranslationError;
 
+use alloc::string::{String,ToString};
+
 /// Encodes an ascii string into a morse code representation
 ///
 /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,13 @@ This crate provides a library for encoding and decoding morse code
 This crate's documentation provides some simple examples on how to use it.
 */
 
+#![no_std]
 #![deny(missing_docs)]
+
+#[macro_use]
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 /// The structure that is returned if the encode or decode functions failed.
 #[derive(Debug)]


### PR DESCRIPTION
Hello,

I am currently working on a project where I need this library to run on bare-metal. Due to this, I had to make some small modifications to the library in order to get it to run without the Rust standard library.

I figured I'd make a PR to here so you can include the changes in your crates.io package.

While I'm at it, I also made a few small improvements to the README for you